### PR TITLE
Enable website run script in Conductor Cloud

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -5,7 +5,7 @@ setup = "./scripts/setup.sh"
 run_mode = "concurrent"
 
 [scripts.run.dev]
-available_in = ["local"]
+available_in = ["local", "cloud"]
 command = "./scripts/serve.sh"
 default = true
 icon = "play"


### PR DESCRIPTION
Makes the existing Conductor dev run script available in both local and cloud workspaces. The script continues to use its existing cloud-safe port fallback and setup flow. Verified in a Conductor cloud sandbox by starting Jekyll and receiving HTTP 200 from the site.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/9a47edfd-d8f5-4ffe-aec8-235d1c0cbf11)
