### PR TITLE
Automate Buttondown publishing for new posts

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -1,0 +1,6 @@
+# @defaultSensitive=false @defaultRequired=false
+# ---
+
+# Buttondown API key with Emails and Sending write access.
+# @required @sensitive @type=string
+BUTTONDOWN_API_KEY=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,13 @@ jobs:
         run: bundle exec jekyll build --strict_front_matter
         env:
           JEKYLL_ENV: production
+      - name: Generate newsletter preview
+        run: >-
+          bundle exec ruby scripts/publish-to-buttondown.rb
+          --output html _posts/2026-08-11-whoport.md
+          > "$RUNNER_TEMP/newsletter-preview.html"
+      - name: Upload newsletter preview
+        uses: actions/upload-artifact@v7
+        with:
+          name: newsletter-preview
+          path: ${{ runner.temp }}/newsletter-preview.html

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -44,3 +44,24 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
+
+  newsletter:
+    name: Publish new posts to Buttondown
+    if: github.event_name == 'push'
+    needs: deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: mise.toml
+          bundler-cache: true
+      - name: Publish newly added posts
+        env:
+          BUTTONDOWN_API_KEY: ${{ secrets.BUTTONDOWN_API_KEY }}
+        run: scripts/publish-new-posts.sh "${{ github.event.before }}" "${{ github.sha }}"

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ _site
 .jekyll-metadata
 .DS_Store
 .jekyll-cache
+.env.local
 
 .claude/

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ JEKYLL_ENV=production mise exec -- bundle exec jekyll build --strict_front_matte
 
 ## Newsletter publishing
 
-After deploying to `main`, GitHub Actions sends new posts to Buttondown.
+After deploying to `main`, GitHub Actions sends newly published posts to Buttondown.
 Create `BUTTONDOWN_API_KEY` with **Emails** and **Sending** write access.
 
 Preview the email with:

--- a/README.md
+++ b/README.md
@@ -34,6 +34,23 @@ To verify a production build, run:
 JEKYLL_ENV=production mise exec -- bundle exec jekyll build --strict_front_matter
 ```
 
+## Newsletter publishing
+
+After deploying to `main`, GitHub Actions sends new posts to Buttondown.
+Create `BUTTONDOWN_API_KEY` with **Emails** and **Sending** write access.
+
+Preview the email with:
+
+```sh
+mise exec -- bundle exec ruby scripts/publish-to-buttondown.rb \
+  --output html _posts/your-post.md > /tmp/newsletter-preview.html
+open /tmp/newsletter-preview.html
+```
+
+Use `--output json` to print the API payload. Jekyll posts with `published: false`
+are not sent. Workflow retries are safe because Buttondown deduplicates each
+request using a SHA-256 idempotency key derived from the post's canonical URL.
+
 ## License
 
 Open sourced under the [MIT license][license].

--- a/scripts/publish-new-posts.sh
+++ b/scripts/publish-new-posts.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-# Finds posts added between two Git revisions and publishes them through the
-# Jekyll-aware Buttondown publisher. Extra arguments are passed to the publisher
-# (for example, --output json).
+# Finds added posts and posts whose `published:` front matter changed between
+# two Git revisions, then passes them to the Jekyll-aware Buttondown publisher.
+# Jekyll filters out posts that remain unpublished. Extra arguments are passed
+# to the publisher (for example, --output json).
 
 set -euo pipefail
 
@@ -23,11 +24,23 @@ if [[ $before =~ ^0+$ ]]; then
 fi
 
 changes=$(mktemp)
-trap 'rm -f "$changes"' EXIT
+modified=$(mktemp)
+trap 'rm -f "$changes" "$modified"' EXIT
 
 git diff --name-only --diff-filter=A -z \
   "$before" "$after" -- "${POST_PATHS[@]}" \
   > "$changes"
+git diff --name-only --diff-filter=M -z -G '^[[:space:]]*published:' \
+  "$before" "$after" -- "${POST_PATHS[@]}" \
+  > "$modified"
+
+while IFS= read -r -d '' post; do
+  if git diff --unified=0 "$before" "$after" -- "$post" \
+    | grep -Eiq '^-[[:space:]]*published:[[:space:]]*false([[:space:]]*(#.*)?)?$'; then
+    printf '%s\0' "$post" >> "$changes"
+  fi
+done < "$modified"
+
 mapfile -d '' -t posts < "$changes"
 
 if (( ${#posts[@]} == 0 )); then

--- a/scripts/publish-new-posts.sh
+++ b/scripts/publish-new-posts.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Finds posts added between two Git revisions and publishes them through the
+# Jekyll-aware Buttondown publisher. Extra arguments are passed to the publisher
+# (for example, --output json).
+
+set -euo pipefail
+
+readonly POST_PATHS=('_posts/*.md' '_posts/*.markdown' '_posts/*.html')
+
+if (( $# < 2 )); then
+  echo "Usage: scripts/publish-new-posts.sh BEFORE_SHA AFTER_SHA [--output json]" >&2
+  exit 2
+fi
+
+before=$1
+after=$2
+shift 2
+
+if [[ $before =~ ^0+$ ]]; then
+  echo "No previous revision; skipping newsletter publishing."
+  exit 0
+fi
+
+changes=$(mktemp)
+trap 'rm -f "$changes"' EXIT
+
+git diff --name-only --diff-filter=A -z \
+  "$before" "$after" -- "${POST_PATHS[@]}" \
+  > "$changes"
+mapfile -d '' -t posts < "$changes"
+
+if (( ${#posts[@]} == 0 )); then
+  echo "No newly added posts to publish."
+  exit 0
+fi
+
+bundle exec ruby scripts/publish-to-buttondown.rb "$@" "${posts[@]}"

--- a/scripts/publish-to-buttondown.rb
+++ b/scripts/publish-to-buttondown.rb
@@ -1,0 +1,164 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# This intentionally uses Ruby so the publisher can ask Jekyll to render posts
+# exactly as the site does. A shell version would need to reimplement or parse
+# Jekyll's front matter, Liquid, Markdown, permalinks, HTML, and JSON escaping.
+
+require "digest"
+require "cgi"
+require "json"
+require "net/http"
+require "nokogiri"
+require "optparse"
+require "uri"
+
+require "jekyll"
+
+API_URL = URI("https://api.buttondown.com/v1/emails")
+# Buttondown reads this leading sentinel and stores the body as rich HTML (its
+# "Fancy" editor mode) instead of interpreting the rendered post as Markdown.
+EDITOR_MODE = "<!-- buttondown-editor-mode: fancy -->"
+OUTPUT_FORMATS = %w[html json].freeze
+
+options = {
+  output: nil,
+}
+
+OptionParser.new do |parser|
+  parser.banner = "Usage: scripts/publish-to-buttondown.rb [options] [_posts/post.md ...]"
+  parser.on("--output FORMAT", OUTPUT_FORMATS, "Render without publishing: html or json") do |format|
+    options[:output] = format
+  end
+end.parse!
+
+def absolute_url(base_url, value)
+  uri = URI(value)
+  return value if uri.absolute? || value.start_with?("#")
+
+  URI.join(base_url, value).to_s
+rescue URI::InvalidURIError
+  value
+end
+
+# Adapts a Jekyll-rendered page for Buttondown's rich-HTML editor. This is not a
+# full HTML-to-email conversion: it extracts the post article and makes relative
+# links and images portable outside the website. Buttondown applies the actual
+# newsletter template and email-client compatibility styles.
+def email_body(post, canonical_url)
+  page = Nokogiri::HTML5(post.output)
+  article = page.at_css("article.post-content")
+  abort "Could not find the rendered post body for #{post.relative_path}." unless article
+
+  article.css("a[href]").each do |link|
+    link["href"] = absolute_url(canonical_url, link["href"])
+  end
+  article.css("img[src]").each do |image|
+    image["src"] = absolute_url(canonical_url, image["src"])
+  end
+
+  "#{EDITOR_MODE}\n#{article.inner_html.strip}\n"
+end
+
+# Wraps the body in only enough markup to open it in a browser. This deliberately
+# adds no styling because Buttondown applies the actual template when sending.
+def preview_document(payload)
+  body = payload.fetch(:body).delete_prefix("#{EDITOR_MODE}\n")
+  subject = CGI.escapeHTML(payload.fetch(:subject).to_s)
+
+  <<~HTML
+    <!doctype html>
+    <html lang="en">
+      <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Preview: #{subject}</title>
+      </head>
+      <body>
+        <main>
+          #{body}
+        </main>
+      </body>
+    </html>
+  HTML
+end
+
+def image_url(site_url, post)
+  image = post.data["image"]
+  value = image.is_a?(Hash) ? image["path"] : image
+  value ? absolute_url(site_url, value) : ""
+end
+
+paths = ARGV.uniq
+
+abort "HTML output accepts exactly one post." if options[:output] == "html" && paths.length != 1
+
+if paths.empty?
+  puts "No newly added posts to publish."
+  exit
+end
+
+unless options[:output] || ENV["BUTTONDOWN_API_KEY"]&.length&.positive?
+  abort "BUTTONDOWN_API_KEY is required to publish an email."
+end
+
+config = Jekyll.configuration(
+  "environment" => "production",
+  "quiet" => true,
+  "strict_front_matter" => true,
+)
+site = Jekyll::Site.new(config)
+site.process
+
+paths.each do |path|
+  relative_path = path.delete_prefix("./").delete_prefix("/")
+  post = site.posts.docs.find { |candidate| candidate.relative_path.delete_prefix("/") == relative_path }
+
+  unless post
+    warn "Skipping #{path}: it is not a published Jekyll post."
+    next
+  end
+  canonical_url = URI.join(site.config.fetch("url"), post.url).to_s
+  payload = {
+    subject: post.data.fetch("title"),
+    body: email_body(post, canonical_url),
+    canonical_url: canonical_url,
+    description: post.data.fetch("description", ""),
+    image: image_url(site.config.fetch("url"), post),
+    status: "sent",
+    metadata: {
+      source: "github_actions",
+      source_path: path,
+      source_commit: ENV.fetch("GITHUB_SHA", "local"),
+    },
+  }
+
+  if options[:output] == "json"
+    puts JSON.pretty_generate(payload)
+    next
+  end
+
+  if options[:output] == "html"
+    puts preview_document(payload)
+    next
+  end
+
+  request = Net::HTTP::Post.new(API_URL)
+  request["Authorization"] = "Token #{ENV.fetch("BUTTONDOWN_API_KEY")}"
+  request["Content-Type"] = "application/json"
+  # Buttondown deduplicates requests with the same X-Idempotency-Key. Deriving
+  # it from the canonical URL makes workflow retries safe for each stable post.
+  request["X-Idempotency-Key"] = Digest::SHA256.hexdigest("clairenord.com:#{canonical_url}")
+  request.body = JSON.generate(payload)
+
+  response = Net::HTTP.start(API_URL.hostname, API_URL.port, use_ssl: true) do |http|
+    http.request(request)
+  end
+
+  unless response.is_a?(Net::HTTPSuccess)
+    abort "Buttondown rejected #{path} (HTTP #{response.code}): #{response.body}"
+  end
+
+  result = JSON.parse(response.body)
+  puts "Published #{path} as #{result.fetch("id", "an email")}."
+end


### PR DESCRIPTION
Automatically publish newly added Jekyll posts to Buttondown after a successful GitHub Pages deployment. Render posts through Jekyll, normalize links and images, and use Buttondown idempotency keys to make workflow retries safe. Add HTML and JSON output modes, upload an unstyled newsletter preview from pull-request CI, and document the required API secret and local preview command.\n\nTests: production Jekyll build, Ruby and shell syntax checks, formatter check, HTML/JSON rendering, and Action-style payload parity.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/d240e246-85bd-4ea9-9eab-b61ae893b058)
