### PR TITLE
Add HTML validation and repair site links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
         run: bundle exec jekyll build --strict_front_matter
         env:
           JEKYLL_ENV: production
+      - name: Validate generated links, images, and scripts
+        run: ./scripts/check-html.sh
       - name: Generate newsletter preview
         run: >-
           bundle exec ruby scripts/publish-to-buttondown.rb

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,7 @@ group :jekyll_plugins do
   gem "jekyll-target-blank", "~> 2.0"
   gem "jemoji", "~> 0.13"
 end
+
+group :test do
+  gem "html-proofer", "~> 5.2"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    Ascii85 (2.0.1)
     activesupport (8.1.3.1)
       base64
       bigdecimal
@@ -25,16 +26,29 @@ GEM
       uri (>= 0.13.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    afm (1.0.0)
+    async (2.44.1)
+      console (~> 1.29)
+      fiber-annotation
+      io-event (~> 1.11)
     base64 (0.3.0)
+    benchmark (0.5.0)
     bigdecimal (4.1.2)
     colorator (1.1.0)
     concurrent-ruby (1.3.8)
     connection_pool (3.0.2)
+    console (1.37.0)
+      fiber-annotation
+      fiber-local (~> 1.1)
+      json
     csv (3.3.6)
     drb (2.2.3)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
+    ethon (0.18.0)
+      ffi (>= 1.15.0)
+      logger
     eventmachine (1.2.7)
     ffi (1.17.4-aarch64-linux-gnu)
     ffi (1.17.4-aarch64-linux-musl)
@@ -44,6 +58,10 @@ GEM
     ffi (1.17.4-x86_64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
     ffi (1.17.4-x86_64-linux-musl)
+    fiber-annotation (0.2.0)
+    fiber-local (1.1.0)
+      fiber-storage
+    fiber-storage (1.0.1)
     forwardable-extended (2.6.0)
     gemoji (4.1.0)
     google-protobuf (4.35.1)
@@ -67,12 +85,24 @@ GEM
     google-protobuf (4.35.1-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
+    hashery (2.1.2)
     html-pipeline (2.14.3)
       activesupport (>= 2)
       nokogiri (>= 1.4)
+    html-proofer (5.2.2)
+      addressable (~> 2.3)
+      async (~> 2.1)
+      benchmark (~> 0.5)
+      nokogiri (~> 1.13)
+      pdf-reader (~> 2.11)
+      rainbow (~> 3.0)
+      typhoeus (~> 1.3)
+      yell (~> 2.0)
+      zeitwerk (~> 2.5)
     http_parser.rb (0.8.1)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
+    io-event (1.19.4)
     jekyll (4.4.1)
       addressable (~> 2.4)
       base64 (~> 0.2)
@@ -144,9 +174,15 @@ GEM
       racc (~> 1.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
+    pdf-reader (2.16.0)
+      Ascii85 (>= 1.0, < 3.0, != 2.0.0)
+      afm (>= 0.2.1, < 2)
+      hashery (~> 2.0)
+      ttfunk
     prism (1.9.0)
     public_suffix (7.0.5)
     racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.4.2)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
@@ -173,11 +209,16 @@ GEM
     securerandom (0.4.1)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
+    ttfunk (1.7.0)
+    typhoeus (1.6.0)
+      ethon (>= 0.18.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.6.0)
     uri (1.1.1)
     webrick (1.9.2)
+    yell (2.2.2)
+    zeitwerk (2.8.3)
 
 PLATFORMS
   aarch64-linux-gnu
@@ -192,23 +233,30 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  html-proofer (~> 5.2)
   jekyll-cache-bust (~> 0.0.1)
   jekyll-target-blank (~> 2.0)
   jemoji (~> 0.13)
   lagrange!
 
 CHECKSUMS
+  Ascii85 (2.0.1) sha256=15cb5d941808543cbb9e7e6aea3c8ec3877f154c3461e8b3673e97f7ecedbe5a
   activesupport (8.1.3.1) sha256=85458765f25ea48b9019c46b6bb3fa5683197bf4280d9f06710a6e8d7a831376
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  afm (1.0.0) sha256=5bd4d6f6241e7014ef090985ec6f4c3e9745f6de0828ddd58bc1efdd138f4545
+  async (2.44.1) sha256=079bce0d019fb27cc58ec110fd9b9af4991d97b801d1c6cc6def1d1954dcf9b2
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bundler (4.0.17) sha256=214e21431b5665dd2f99df8a5511c6b151d7a72e8015c8b38f8b775b61cbb6c1
   colorator (1.1.0) sha256=e2f85daf57af47d740db2a32191d1bdfb0f6503a0dfbc8327d0c9154d5ddfc38
   concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
+  console (1.37.0) sha256=8093b286c2595a063849c098594fee5155ecc7967d36f3aa8cbe7569c8f3efd7
   csv (3.3.6) sha256=aba61e7e507a66f03d45cb1f3c4b6359861c3504038b422962875dce099e4456
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   em-websocket (0.5.3) sha256=f56a92bde4e6cb879256d58ee31f124181f68f8887bd14d53d5d9a292758c6a8
+  ethon (0.18.0) sha256=b598afc9f30448cb068b850714b7d6948e941476095d04f90a4ac65b8d6efcb2
   eventmachine (1.2.7) sha256=994016e42aa041477ba9cff45cbe50de2047f25dd418eba003e84f0d16560972
   ffi (1.17.4-aarch64-linux-gnu) sha256=b208f06f91ffd8f5e1193da3cae3d2ccfc27fc36fba577baf698d26d91c080df
   ffi (1.17.4-aarch64-linux-musl) sha256=9286b7a615f2676245283aef0a0a3b475ae3aae2bb5448baace630bb77b91f39
@@ -218,6 +266,9 @@ CHECKSUMS
   ffi (1.17.4-x86_64-darwin) sha256=aa70390523cf3235096cf64962b709b4cfbd5c082a2cb2ae714eb0fe2ccda496
   ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
   ffi (1.17.4-x86_64-linux-musl) sha256=3fdf9888483de005f8ef8d1cf2d3b20d86626af206cbf780f6a6a12439a9c49e
+  fiber-annotation (0.2.0) sha256=7abfadf1d119f508867d4103bf231c0354d019cc39a5738945dec2edadaf6c03
+  fiber-local (1.1.0) sha256=c885f94f210fb9b05737de65d511136ea602e00c5105953748aa0f8793489f06
+  fiber-storage (1.0.1) sha256=f48e5b6d8b0be96dac486332b55cee82240057065dc761c1ea692b2e719240e1
   forwardable-extended (2.6.0) sha256=1bec948c469bbddfadeb3bd90eb8c85f6e627a412a3e852acfd7eaedbac3ec97
   gemoji (4.1.0) sha256=734434020cbe964ea9d19086798797a47d23a170892de0ce55b74aa65d2ddc1a
   google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
@@ -227,9 +278,12 @@ CHECKSUMS
   google-protobuf (4.35.1-x86_64-darwin) sha256=66b62b4df00931018a692806df66393efa960d6d2b7da69735187249f950d3ee
   google-protobuf (4.35.1-x86_64-linux-gnu) sha256=c786439087512a3fbd199e9897d265b855f951d4027e218ea55e858d45969edd
   google-protobuf (4.35.1-x86_64-linux-musl) sha256=91890eb0002934a339fdb7d77a147c46b7474b6799db27872b747b905837f744
+  hashery (2.1.2) sha256=d239cc2310401903f6b79d458c2bbef5bf74c46f3f974ae9c1061fb74a404862
   html-pipeline (2.14.3) sha256=8a1d4d7128b2141913387cac0f8ba898bb6812557001acc0c2b46910f59413a0
+  html-proofer (5.2.2) sha256=6e5e63c89ef9413246eeffaeba8dd03db62546992d7a2b85d166ac2a5903a241
   http_parser.rb (0.8.1) sha256=9ae8df145b39aa5398b2f90090d651c67bd8e2ebfe4507c966579f641e11097a
   i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5
+  io-event (1.19.4) sha256=c291146e2e70849b9d6b64078f8e98f0154bfd3bc4f9759861ff13e9895e0cce
   jekyll (4.4.1) sha256=4c1144d857a5b2b80d45b8cf5138289579a9f8136aadfa6dd684b31fe2bc18c1
   jekyll-cache-bust (0.0.1) sha256=538ffe6d48f56d933b435bf32d4fef19ff1082cae7d6d8bc737fc13a9c86ba8c
   jekyll-feed (0.17.0) sha256=689aab16c877949bb9e7a5c436de6278318a51ecb974792232fd94d8b3acfcc3
@@ -257,9 +311,11 @@ CHECKSUMS
   nokogiri (1.19.4-x86_64-linux-gnu) sha256=379fae440b28915e3f19d752ce2dcf8465ed2b2fbefd2a7ca0dd497bc981a06a
   nokogiri (1.19.4-x86_64-linux-musl) sha256=17dfb7c1fa194ae02fbf7c51a7afc8d278045ab3fdacfd86f91d02d7b274470b
   pathutil (0.16.2) sha256=e43b74365631cab4f6d5e4228f812927efc9cb2c71e62976edcb252ee948d589
+  pdf-reader (2.16.0) sha256=bf1b5564c085264d8279bde3cf1467778b75841494d20c0fe7da3dad475f3732
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
   rb-fsevent (0.11.2) sha256=43900b972e7301d6570f64b850a5aa67833ee7d87b458ee92805d56b7318aefe
   rb-inotify (0.11.1) sha256=a0a700441239b0ff18eb65e3866236cd78613d6b9f78fea1f9ac47a85e47be6e
@@ -276,10 +332,14 @@ CHECKSUMS
   sass-embedded (1.102.0-x86_64-linux-musl) sha256=9e3c15eb5d83784adf3b946d4fc5d8a32aed25566a2fee939f25dd1e1d217ddf
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   terminal-table (3.0.2) sha256=f951b6af5f3e00203fb290a669e0a85c5dd5b051b3b023392ccfd67ba5abae91
+  ttfunk (1.7.0) sha256=2370ba484b1891c70bdcafd3448cfd82a32dd794802d81d720a64c15d3ef2a96
+  typhoeus (1.6.0) sha256=bacc41c23e379547e29801dc235cd1699b70b955a1ba3d32b2b877aa844c331d
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
   unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
+  yell (2.2.2) sha256=1d166f3cc3b6dc49a59778ea7156ed6d8de794c15106d48ffd6cbb061b9b26bc
+  zeitwerk (2.8.3) sha256=2c85125a8467ce069e20123d1e709a08955c9d29c118c25b46b7b7fafdbb92e5
 
 BUNDLED WITH
   4.0.17

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ To verify a production build, run:
 
 ```sh
 JEKYLL_ENV=production mise exec -- bundle exec jekyll build --strict_front_matter
+mise exec -- ./scripts/check-html.sh
 ```
 
 ## Newsletter publishing

--- a/_posts/2017-10-31-making-your-first-samsung-gear-s3-app.md
+++ b/_posts/2017-10-31-making-your-first-samsung-gear-s3-app.md
@@ -9,48 +9,49 @@ image:
 tags: [samsung, samsung gear s3, smartwatch, writing]
 ---
 
-When I started my research project in the MIT [D-Lab](https://d-lab.mit.edu/research-about) [Mobile Technology Lab](http://www.mobiletechnologylab.org/) I was excited to build my first smartwatch app using the [Samsung Gear S3](https://www.samsung.com/us/explore/gear-s3/). Despite being super excited about the project, setting up the development environment took me an entire month :anguished: Here’s how to get to the Hello World stage 10x faster than I did.
+<!-- HTMLProofer: preserve this historical URL; its HTTP site works but its HTTPS endpoint does not. -->
+When I started my research project in the MIT [D-Lab][d-lab] [Mobile Technology Lab][mtl]{: data-proofer-ignore="" } I was excited to build my first smartwatch app using the [Samsung Gear S3][gear-s3]. Despite being super excited about the project, setting up the development environment took me an entire month :anguished: Here’s how to get to the Hello World stage 10x faster than I did.
 
-![]({{ site.github.url }}/assets/img/watch/goal.jpeg)
+![A Samsung Gear S3 displaying “Hello D-Lab!” and the time]({{ site.github.url }}/assets/img/watch/goal.jpeg)
 _The goal for this tutorial._
 
-The Samsung Gear S3 uses an open-source operating system called [Tizen](https://www.tizen.org/?langswitch=en) that’s based on the Linux kernel. You can program apps for the watch in C (“Native”) or with HTML/CSS/JS (“Web”). My project needs fast real-time signal processing, so we chose Native.
+The Samsung Gear S3 uses an open-source operating system called [Tizen][tizen] that’s based on the Linux kernel. You can program apps for the watch in C (“Native”) or with HTML/CSS/JS (“Web”). My project needs fast real-time signal processing, so we chose Native.
 
-The source tutorial for this post is “[**Creating Your First Tizen Wearable Native Watch Application**](https://developer.tizen.org/ko/development/training/native-application/getting-started/creating-your-first-tizen-wearable-native-watch-application?langredirect=1#run)” by [Tizen Developers](https://developer.tizen.org/?langswitch=en). The info below should fill in all the gaps in the tutorial.
+The source tutorial for this post is “[**Creating Your First Tizen Wearable Native Watch Application**][tizen-tutorial]” by [Tizen Developers][tizen-developers]. The info below should fill in all the gaps in the tutorial.
 
 *This project is up-to-date as of 20 March 2018. It uses Tizen Studio 2.2 and Wearable 3.0.*
 
 ### Installing Tizen Studio
 
-1. Make sure you have enough space to download and install the [Tizen Studio](https://developer.tizen.org/development/tizen-studio/download) [IDE](https://en.wikipedia.org/wiki/Integrated_development_environment). It’s ~5GB!
+1. Make sure you have enough space to download and install the [Tizen Studio][tizen-studio] [IDE][ide]. It’s ~5GB!
 2. In the Tizen Studio package manager, install everything for the **3.0 wearable**. This was my first big stumbling block. Also be sure to install the **Samsung Certificate Extension** and the **Samsung Wearable Extension** under “Extras”.
 
-Once you’ve installed Tizen Studio, you can go through the “[Creating a Project](https://developer.tizen.org/ko/development/training/native-application/getting-started/creating-your-first-tizen-wearable-native-watch-application?langredirect=1#create)”, “[Managing the Application Configuration](https://developer.tizen.org/ko/development/training/native-application/getting-started/creating-your-first-tizen-wearable-native-watch-application?langredirect=1#configuration)”, and “[Building Your Application](https://developer.tizen.org/ko/development/training/native-application/getting-started/creating-your-first-tizen-wearable-native-watch-application?langredirect=1#build)” sections of the tutorial.
+Once you’ve installed Tizen Studio, you can go through the “[Creating a Project][tizen-tutorial-create]”, “[Managing the Application Configuration][tizen-tutorial-configuration]”, and “[Building Your Application][tizen-tutorial-build]” sections of the tutorial.
 
 ### Running the Emulator
 
 The emulator is basically a little watch that runs on your computer. It takes a long time to start, but you can tell it’s successfully starting up by the boot messages at the top of the emulator watch face.
 
-![]({{ site.github.url }}/assets/img/watch/emu.png)
+![A Tizen wearable emulator running inside Tizen Studio]({{ site.github.url }}/assets/img/watch/emu.png)
 _This is a good sign._
 
-Start the emulator from the Tizen Emulator Manager window. You know it’s ready when it shows up in the Tizen Studio Connection Explorer window. If you have issues running the emulator on OSX, you may need to install HAX from [here](https://software.intel.com/en-us/articles/intel-hardware-accelerated-execution-manager-intel-haxm) and follow [these](https://stackoverflow.com/questions/26455759/installing-haxm-on-osx-yosemite) instructions to install it. TL;DR: run `sudo kextload -bundle-id com.intel.kext.intelhaxmand` then restart Tizen Studio. After this, you need to set up security certificates.
+Start the emulator from the Tizen Emulator Manager window. You know it’s ready when it shows up in the Tizen Studio Connection Explorer window. If you have issues running the emulator on OSX, you may need to install [Intel HAXM][haxm] and follow [these instructions][haxm-instructions] to install it. TL;DR: run `sudo kextload -bundle-id com.intel.kext.intelhaxmand` then restart Tizen Studio. After this, you need to set up security certificates.
 
 ### Security Certificate Profiles
 
 This is the mistake that took me the most time to figure out, and it is completely glossed over in the tutorial. Essentially, you need to go to Tools>Certificate Manager and click “**+**” to make new certificate. You have to make a Tizen certificate for the emulator to work, and a **Samsung** certificate for the app to run on the actual watch. For the Tizen certificate, choose “Partner” privilege level.
 
-![]({{ site.github.url }}/assets/img/watch/cert.png)
+![Tizen Certificate Manager with the Samsung certificate profile selected]({{ site.github.url }}/assets/img/watch/cert.png)
 _You need the one on the right too!!_
 
 It should be fairly straightforward to follow the steps to set up both certificates from there. You can follow the rest of the Tizen Developers tutorial to run the app on the watch emulator with the Tizen certificate profile.
 
-![]({{ site.github.url }}/assets/img/watch/huzzah.png)
+![The completed Hello D-Lab watch face running in the emulator]({{ site.github.url }}/assets/img/watch/huzzah.png)
 _Huzzah!_
 
 ### Running on the real watch
 
-Follow along with the tutorial section “[Running on a Target Device](https://developer.tizen.org/ko/development/training/native-application/getting-started/creating-your-first-tizen-wearable-native-watch-application?langredirect=1#target)”. In particular, be sure to turn on the device WiFi and Bluetooth, connect your computer to the same WiFi network, and make sure both your laptop and device have the correct date and time. Also be sure to check your device IP address each time you connect to WiFi, because it may change.
+Follow along with the tutorial section “[Running on a Target Device][tizen-tutorial-target]”. In particular, be sure to turn on the device WiFi and Bluetooth, connect your computer to the same WiFi network, and make sure both your laptop and device have the correct date and time. Also be sure to check your device IP address each time you connect to WiFi, because it may change.
 
 When I ran `./sdb connect <watch IP>` I never actually got a notification on my watch saying “Allow Gear to read log data, copy files,…”. I just got a notification that said “RSA key fingerprint:…” and clicked the check mark. I had to reset my watch once to get a notification to pop up at all.
 
@@ -60,10 +61,24 @@ Like it says in the tutorial, you know the watch is correctly connected when you
 
 Now, you should be able to select the Samsung security profile, then continue the tutorial with Run As>Tizen Native Application, select the watch face, and see your beautiful new app!
 
-![]({{ site.github.url }}/assets/img/watch/done.jpeg)
+![A Samsung Gear S3 displaying a thank-you message in front of the app’s source code]({{ site.github.url }}/assets/img/watch/done.jpeg)
 
 Feel free to email me (cnord@school) if you have any questions, comments, or tips about Samsung Gear development.
 
 _This blog post was cross-posted on Medium [here][medium]._
 
+[d-lab]: https://d-lab.mit.edu/research-about
+[mtl]: http://www.mobiletechnologylab.org/
+[gear-s3]: https://www.samsung.com/us/explore/gear-s3/
+[tizen]: https://www.tizen.org/?langswitch=en
+[tizen-tutorial]: https://developer.samsung.com/galaxy-watch-tizen/creating-your-first-app/native.html#run
+[tizen-tutorial-create]: https://developer.samsung.com/galaxy-watch-tizen/creating-your-first-app/native.html#create
+[tizen-tutorial-configuration]: https://developer.samsung.com/galaxy-watch-tizen/creating-your-first-app/native.html#configuration
+[tizen-tutorial-build]: https://developer.samsung.com/galaxy-watch-tizen/creating-your-first-app/native.html#build
+[tizen-tutorial-target]: https://developer.samsung.com/galaxy-watch-tizen/creating-your-first-app/native.html#target
+[tizen-developers]: https://developer.tizen.org/?langswitch=en
+[tizen-studio]: https://developer.tizen.org/development/tizen-studio/download
+[ide]: https://en.wikipedia.org/wiki/Integrated_development_environment
+[haxm]: https://software.intel.com/en-us/articles/intel-hardware-accelerated-execution-manager-intel-haxm
+[haxm-instructions]: https://stackoverflow.com/questions/26455759/installing-haxm-on-osx-yosemite
 [medium]: https://medium.com/@cnord/making-your-first-samsung-gear-s3-app-363947cdf7fd

--- a/_posts/2018-01-02-get-to-know-hkn--tutoring.md
+++ b/_posts/2018-01-02-get-to-know-hkn--tutoring.md
@@ -9,22 +9,22 @@ image:
 tags: [education, mit, tutoring, writing]
 ---
 
-[HKN](https://hkn.mit.edu/), the Course 6 honor society at MIT, is often thought of as the club that hosts free food study breaks, the [underground guide](https://underground-guide.mit.edu) to Course 6 classes, and the occasional resume review event. However, there’s much more than free boba and Chipotle— one of the most important services HKN offers is the opportunity to tutor and be tutored.
+[HKN][hkn], the Course 6 honor society at MIT, is often thought of as the club that hosts free food study breaks, the [underground guide][underground-guide] to Course 6 classes, and the occasional resume review event. However, there’s much more than free boba and Chipotle— one of the most important services HKN offers is the opportunity to tutor and be tutored.
 
-![]({{ site.github.url }}/assets/img/tutor.jpeg)
+![Two students working together at laptops during an HKN tutoring session]({{ site.github.url }}/assets/img/tutor.jpeg)
 _HKN eligible Stef Ren ’19 reviews a student’s resume._
 
 #### What is HKN Tutoring?
 
 Tutoring is the second-largest branch of HKN after the Underground Guide, with 83 student tutors in fall 2017. Tutors for HKN submit the classes and number of hours they’re willing to tutor, and they are manually matched with tutees by the HKN tutoring officers. The tutor and tutee typically meet for an hour once a week, discussing anything from pset questions to exam practice problems to topics from lecture in more depth.
 
-The most popular classes for tutoring are large classes like 6.006, 6.046, 6.036, and 6.004. 205 students were matched with tutors this semester, which means over 20% of students in the department are involved in HKN tutoring ([source][registrar]). HKN member Justin Xiao ’17 discusses tutoring statistics in more detail [here](https://medium.com/mit-hkn/mit-hkn-tutoring-service-a303d6d6bfa5).
+The most popular classes for tutoring are large classes like 6.006, 6.046, 6.036, and 6.004. 205 students were matched with tutors this semester, which means over 20% of students in the department are involved in HKN tutoring ([source][registrar]). HKN member Justin Xiao ’17 discusses tutoring statistics in more detail [here][tutoring-statistics].
 
 #### Why request a tutor?
 
 Office hours for these large Course 6 classes tend to be very crowded, which means TAs have to focus on immediate needs like psets or exams without reviewing concepts. Unlike office hours, lectures, or group psetting, tutoring time is solely focused on *you* and your understanding of the subject. You’re paired with the same tutor all semester, so you can build a personal relationship with them beyond transactional Q&A. Your tutor knows you, and can encourage you and adapt to your learning style.
 
-Tutoring can be especially helpful for classes like 6.036, which switched to a [flipped classroom](https://en.wikipedia.org/wiki/Flipped_classroom) style for the first time this semester. HKN eligible Sooraj Boominathan ’19 notes that “[tutoring] is the first time students might be getting the subject explained to them by a real person, and not just a video.”
+Tutoring can be especially helpful for classes like 6.036, which switched to a [flipped classroom][flipped-classroom] style for the first time this semester. HKN eligible Sooraj Boominathan ’19 notes that “[tutoring] is the first time students might be getting the subject explained to them by a real person, and not just a video.”
 
 #### Why tutor for HKN?
 
@@ -36,11 +36,19 @@ If you’ve considered TAing a class, tutoring is a great lower-commitment way t
 
 #### In Summary
 
-Peer teaching is a key part of the MIT undergraduate experience! Take advantage of this opportunity and sign up to tutor or be tutored [**here**](https://hkn.scripts.mit.edu/tutoring/). Tutors are in high demand, so be sure to sign up early if you request tutoring for a popular class.
+Peer teaching is a key part of the MIT undergraduate experience! Take advantage of this opportunity and sign up to tutor or be tutored [**here**][signup]. Tutors are in high demand, so be sure to sign up early if you request tutoring for a popular class.
 
-If you want announcements for HKN events, add yourself to hkn-interest@ [here](https://groups.mit.edu/webmoira/list/hkn-interest). If you have ideas for how to improve tutoring or anything else Course 6, contact HKN at [hkn-officers@mit.edu](mailto:hkn-officers@mit.edu), or the tutoring officers in particular at [hkn-tutoring@mit.edu](mailto:hkn-tutoring@mit.edu).
+If you want announcements for HKN events, add yourself to hkn-interest@ [here][hkn-interest]. If you have ideas for how to improve tutoring or anything else Course 6, contact HKN at [hkn-officers@mit.edu][hkn-officers-email], or the tutoring officers in particular at [hkn-tutoring@mit.edu][hkn-tutoring-email].
 
 _Thanks to Nalini Singh and Noah Moroze for feedback. This blog post was cross-posted on Medium [here][medium]._
 
-[registrar]: http://web.mit.edu/registrar/stats/majors/index.html "MIT Registrar’s Office Enrollment Statistics, Fall 2017–2018"
+[hkn]: https://hkn.mit.edu/
+[underground-guide]: https://underground-guide.mit.edu
+[tutoring-statistics]: https://medium.com/mit-hkn/mit-hkn-tutoring-service-a303d6d6bfa5
+[flipped-classroom]: https://en.wikipedia.org/wiki/Flipped_classroom
+[signup]: https://hkn-tutoring2.mit.edu/
+[hkn-interest]: https://groups.mit.edu/webmoira/list/hkn-interest
+[hkn-officers-email]: mailto:hkn-officers@mit.edu
+[hkn-tutoring-email]: mailto:hkn-tutoring@mit.edu
+[registrar]: https://registrar.mit.edu/stats-reports/majors-count/2017-2018 "MIT Registrar’s Office Enrollment Statistics, Fall 2017–2018"
 [medium]: https://medium.com/mit-hkn/get-to-know-hkn-tutoring-b07267128c93

--- a/_posts/2018-01-09-how-to-un-break-your-jaw.md
+++ b/_posts/2018-01-09-how-to-un-break-your-jaw.md
@@ -23,12 +23,12 @@ a scrape on my chin and my ear was bleeding.
 My mom rushed me to the dentist, where they did a [panoramic dental
 x-ray][panoramic] to find that my jaw was fractured in two places.
 
-![]({{ site.github.url }}/assets/img/jaw/2.jpeg)
+![A panoramic dental X-ray showing the jaw fracture before surgery]({{ site.github.url }}/assets/img/jaw/2.jpeg)
 _The original panoramic x-ray result. The white line across my lower middle
 teeth is my [permanent retainer][permanent-retainer]!_
 {: .caption}
 
-![]({{ site.github.url }}/assets/img/jaw/3.jpeg)
+![The panoramic dental X-ray with the two fracture sites circled in red]({{ site.github.url }}/assets/img/jaw/3.jpeg)
 _The two fractures: the body fracture on my right and the condylar fracture high
 up on my left._
 {: .caption}
@@ -76,7 +76,7 @@ For the fracture on the jaw body, the doctors decided to do an “[internal
 fixation][internal-fixation]”, where they put a small titanium plate across the
 break to fixate it. The plate looks like this:
 
-![]({{ site.github.url }}/assets/img/jaw/plate.png)
+![A hand-drawn fixation plate with an arrow labeling its screw holes]({{ site.github.url }}/assets/img/jaw/plate.png)
 
 The plate goes from a bit before the corner of my jaw on the right to a little
 past the curve at the front of my chin. The plate is 10cm long (about the length
@@ -91,7 +91,7 @@ an invasive surgery and could have caused problems with articulating my jaw.
 Instead, they decided to temporarily lock my jaw shut with [arch
 bars][arch-bars] and elastic bands.
 
-![]({{ site.github.url }}/assets/img/jaw/arch-bars.jpeg)
+![Arch bars wired around the upper and lower teeth of a model jaw]({{ site.github.url }}/assets/img/jaw/arch-bars.jpeg)
 _Arch bars ([image source][arch-bar-img])_
 {: .caption}
 
@@ -111,7 +111,7 @@ extensively so I wouldn’t need to during surgery, and talked with the main [or
 surgeon][pokorny] and anesthesiologist. They gave me the KO medication through
 my IV and I was completely out for the 3–3.5hr surgery.
 
-![]({{ site.github.url }}/assets/img/jaw/1.jpeg)
+![A postoperative panoramic X-ray showing arch bars and a plate fixed to the lower jaw]({{ site.github.url }}/assets/img/jaw/1.jpeg)
 _The plate and arch bars after the surgery (same as first image)._
 {: .caption}
 
@@ -203,7 +203,7 @@ As far as swelling, Dr. Kim said that 50% of the swelling goes down in the first
 6 weeks, and the next 50% goes away in the next year. For me most of the
 swelling went away after 2.5 weeks, though.
 
-![]({{ site.github.url }}/assets/img/jaw/hackmit.jpeg)
+![Claire with two fellow HackMIT organizers wearing matching event shirts]({{ site.github.url }}/assets/img/jaw/hackmit.jpeg)
 _Me (left) struggling to smile normally at [HackMIT][hackmit] 2017 (2.5 weeks
 post-op). You can see my arch bars peeking out, and my right side is still a
 little puffy._
@@ -229,7 +229,7 @@ At this week’s doctor’s appointment I was put in lighter “guided elastics�
 let me open my mouth. I had an elastic band on each side of my mouth in the
 following positions:
 
-![]({{ site.github.url }}/assets/img/jaw/elastics.png)
+![A hand-drawn diagram numbering the five elastic positions around the teeth]({{ site.github.url }}/assets/img/jaw/elastics.png)
 _I remembered the positions as 5–2–3–4, like room 5-234 for HackMIT meetings!_
 {: .caption}
 
@@ -240,7 +240,7 @@ didn’t really get around to doing the jaw exercises 3 times a day, but I did d
 2 times (morning and night). I also stopped taking ibuprofen for pain around
 this time.
 
-![]({{ site.github.url }}/assets/img/jaw/elastics-irl.jpeg)
+![A close-up dental exam showing elastics attached to the arch bars]({{ site.github.url }}/assets/img/jaw/elastics-irl.jpeg)
 _Guiding elastics in my mouth IRL._
 {: .caption}
 
@@ -313,7 +313,7 @@ I started using my electric toothbrush and flossing too, which felt amazing
 I was so excited to have the arch bars gone!! There were 3 possible anesthesia
 methods to remove my arch bars:
 
-- Swish [lidocaine](https://en.wikipedia.org/wiki/Lidocaine) in my mouth: tastes
+- Swish [lidocaine][lidocaine] in my mouth: tastes
   bad, but it’s easy. Maybe not as numbing as the other options.
 - General anesthetic: going totally under. It’s kind of a big deal and takes a
   lot of time for how short the operation is.
@@ -327,7 +327,7 @@ She untwisted the wires, snipped them short, then pulled them around and out. I
 grimaced for a few of the pulls, but it was fairly quick and I _really_ wanted
 it all gone.
 
-![]({{ site.github.url }}/assets/img/jaw/bars-out.jpeg)
+![Claire lifting her lip to show her teeth after the arch bars were removed]({{ site.github.url }}/assets/img/jaw/bars-out.jpeg)
 _Imprint of the removed arch bar!_
 {: .caption}
 
@@ -375,19 +375,20 @@ cross-posted on Medium [here][medium]._
 [medium]: https://medium.com/@cnord/how-to-un-break-your-jaw-f6f24c269c88
 [panoramic]: https://en.wikipedia.org/wiki/Panoramic_radiograph
 [permanent-retainer]: https://en.wikipedia.org/wiki/Retainer_(orthodontics)#Fixed_retainers
-[mandibular-fractures]: https://en.wikipedia.org/wiki/Mandible#/media/File:Mandbular_fractures.png
+[mandibular-fractures]: https://commons.wikimedia.org/wiki/File:Mandbular_fractures.png
 [hospital]: https://www.beaumont.org/locations/beaumont-hospital-royal-oak
-[ct-scan]: https://en.wikipedia.org/wiki/CT_scan#Extremities
+[ct-scan]: https://en.wikipedia.org/wiki/CT_scan#Axial_skeleton_and_extremities
 [internal-fixation]: https://en.wikipedia.org/wiki/Internal_fixation
-[arch-bars]: https://www2.aofoundation.org/wps/portal/!ut/p/a0/04_Sj9CPykssy0xPLMnMz0vMAfGjzOKN_A0M3D2DDbz9_UMMDRyDXQ3dw9wMDAx8jfULsh0VAdAsNSU!/?BackMode=true&bone=CMF&contentUrl=%2Fsrg%2Fpopup%2Fadditional_material%2F91%2FX10_MMF.jsp&popupStyle=diagnosis&segment=Mandible&soloState=true#JumpLabelNr4
-[arch-bar-img]: https://www2.aofoundation.org/wps/portal/!ut/p/a1/04_Sj9CPykssy0xPLMnMz0vMAfGjzOKN_A0M3D2DDbz9_UMMDRyDXQ3dw9wMDAx8jYEKIvEocDQnTr8BDuBoQEi_l35Uek5-EtipkY55ScYW6fpRRalpqUWpRXqlRUDhjJKSgmIrVQNVg_Lycr30_Pz0nFS95PxcVQNsWjLyi0v0I1BV6hfkhkZU-aSGAwDYYmkN/dl5/d5/L2dJQSEvUUt3QS80SmlFL1o2XzJPMDBHSVMwS09PVDEwQVNFMUdWRjAwME0z/?ActiveNumber=1&StepPos=65&contentUrl=%2Fsrg%2Fpopup%2Fadditional_material%2F91%2FX10_MMF.enl.jsp&soloState=true
-[pokorny]: https://doctors.beaumont.org/provider/Aaron+Pokorny/227215#provider-details-experience
+[arch-bars]: https://surgeryreference.aofoundation.org/cmf/basic-technique/maxillomandibular-fixation-mmf
+[arch-bar-img]: https://media.aofoundation.org/-/jssmedia/surgery/91/91_x010_i180.png?w=665
+[pokorny]: https://doctors.beaumont.org/provider/Aaron+Pokorny/227215
 [ensure]: https://ensure.com/
 [premier-protein]: https://www.premierprotein.com/
-[mgh]: http://www.massgeneral.org/
+[mgh]: https://www.massgeneral.org/
 [hackmit]: https://hackmit.org
 [skeletonized]: https://medical-dictionary.thefreedictionary.com/skeletonize
 [waterpik]: https://www.waterpik.com/oral-health/products/dental-water-flosser/
-[tootsie-roll]: https://en.wikipedia.org/wiki/Tootsie_Roll#Alternate_flavors
+[tootsie-roll]: https://en.wikipedia.org/wiki/Tootsie_Roll#Alternative_flavors
 [soylent]: https://www.soylent.com/
 [orthodontic-wax]: https://www.wikihow.com/Apply-Dental-Wax-on-Braces
+[lidocaine]: https://en.wikipedia.org/wiki/Lidocaine

--- a/_posts/2019-03-14-tech-deep-dive--object-detection-ensembles-as-graph-cliques.md
+++ b/_posts/2019-03-14-tech-deep-dive--object-detection-ensembles-as-graph-cliques.md
@@ -11,24 +11,24 @@ tags: [ml, security, ai, startup, writing]
 
 Object detection is one important type of computer vision task: given an image, localize and identify the relevant objects in it.
 
-![]({{ site.github.url }}/assets/img/obj/cat-dog.jpeg)
-_Photo by [Ancaro Project](https://unsplash.com/photos/6VQlKJp2vpo?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText) on [Unsplash](https://unsplash.com/?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText)_
+![A sleeping dog and cat enclosed by object-detection boxes labeled DOG 80% and CAT 95%]({{ site.github.url }}/assets/img/obj/cat-dog.jpeg)
+_Photo by [Ancaro Project][ancaro-project] on [Unsplash][unsplash]_
 
-Object detection algorithms can solve problems difficult for humans, like identifying vehicle models from satellite images, counting the number of people in a crowd, or rejecting unripe fruits from a conveyor belt of fresh produce. The last example is what’s known as a sporadic visual search problem, where a huge stream of repetitive data contains anomalies only infrequently and sporadically. Humans struggle with these types of problems due to [cognitive fatigue.](https://medium.com/synapse-blog/tsa-missed-at-least-three-firearms-in-2018-why-theyll-keep-missing-threats-in-2019-5176ea0773bf) Object detection algorithms, however, [excel at this](https://medium.com/synapse-blog/ai-outperforms-certified-xray-operators-972932086f2e).
+Object detection algorithms can solve problems difficult for humans, like identifying vehicle models from satellite images, counting the number of people in a crowd, or rejecting unripe fruits from a conveyor belt of fresh produce. The last example is what’s known as a sporadic visual search problem, where a huge stream of repetitive data contains anomalies only infrequently and sporadically. Humans struggle with these types of problems due to [cognitive fatigue.][cognitive-fatigue] Object detection algorithms, however, [excel at this][ai-performance].
 
 A perfect example of the sporadic visual search problem is X-ray baggage screening at museums. At the entrance to a museum, security operators may scan passengers’ bags with X-ray machines to detect threats like knives or handguns. Baggage screeners see thousands of bags a day, but still need to identify the single bag that contains a threat.
 
-![]({{ site.github.url }}/assets/img/obj/museum.jpeg)
+![Visitors passing through an X-ray security checkpoint outside a museum]({{ site.github.url }}/assets/img/obj/museum.jpeg)
 _An X-ray scanner at the entrance to the Louvre museum._
 
 At Synapse Technology, we use an object detection model to tackle this problem. A *model* in this context is an algorithm trained on a large number of labeled examples to solve a task. Let’s train an object detection model, then run it against each X-ray image the bag screener inspects.
 
-![]({{ site.github.url }}/assets/img/obj/ez-knife.png)
+![An X-ray of a suitcase with a clearly visible knife detected at 99 percent confidence]({{ site.github.url }}/assets/img/obj/ez-knife.png)
 _A straightforward example: the knife stands out in this bag._
 
 Detection can get much more difficult, though, depending on the bag contents and arrangement.
 
-![]({{ site.github.url }}/assets/img/obj/hard-knife-blank.png)
+![A cluttered suitcase X-ray containing a partially obscured knife]({{ site.github.url }}/assets/img/obj/hard-knife-blank.png)
 _This bag contains a knife. Can you spot it?_
 
 It’s hard to tell whether this bag contains a threat, even with a very good object detection model. That’s why we use multiple models in *ensemble* to do our detections. If two models both detect the same object, there’s a much higher chance that something is actually there. Using multiple models can also improve detection rate and lower false alarms by making the whole system more robust towards uncertain/difficult cases. Ensemble detection also allows us to compare different model architectures against each other to continuously improve our product. Finally, it allows us to scale the number of threat classes we support: each model supports some set of threats, and ensemble detection makes it easy to incorporate a new model’s set of threats into the ensemble.
@@ -41,7 +41,7 @@ Implementing ensemble detection presents additional challenges beyond single obj
 
 Suppose we have two object detection models, Model A and Model B. Each of them has detected some objects in the image, and each detection has an associated *confidence score.*
 
-![]({{ site.github.url }}/assets/img/obj/hard-knife-label.png)
+![The cluttered suitcase X-ray with two overlapping knife detections at 40 and 50 percent confidence]({{ site.github.url }}/assets/img/obj/hard-knife-label.png)
 _The two different models have detected a threat. Note that is the same image as the previous one._
 
 Model A (red) and Model B (yellow) have both detected a knife in the top right corner of the image, but neither model has a high enough confidence score alone for us to conclude that there is a threat in the image. If we consider the models as an *ensemble*, though, we observe that since two of their detections overlap, they probably refer to the same object. Given that they refer to the same object, there is a much greater probability that something is actually there. For example, if the confidence scores are the probability that each detection is a true positive (rather than a false positive), then the probability that the *ensemble* is a true detection is 0.7, which is greater than either detection alone (see calculations below).
@@ -70,16 +70,16 @@ Ensemble detection can improve the outcome of this example, but also even more c
 
 Let’s consider a hypothetical example with the same two models, but more inferences:
 
-![]({{ site.github.url }}/assets/img/obj/ex-1.jpeg)
+![Four overlapping knife detections from two object-detection models]({{ site.github.url }}/assets/img/obj/ex-1.jpeg)
 _Model A and Model B have detected more objects in this hypothetical image. Some of these perceived objects overlap._
 
 In this case, we can’t just group overlapping inferences as one “ground truth object” like in the first example because two of Model B’s inferences overlap. Model B thinks that there are *two* different overlapping objects in the lower half of the image, but Model A thinks that there is one. How do we group them? What if there were even more inferences than this? Let’s model this as a graph problem.
 
 #### Graph model for inference cliques
 
-Create a vertex for each inference. Let the vertex’s *color* indicate the model it came from (e.g. red for Model A, yellow for Model B). Draw an edge between two inferences if their bounding boxes overlap. Weight this edge by how much they overlap, in particular, their [*intersection over union*](https://en.wikipedia.org/wiki/Jaccard_index) (IoU) score.
+Create a vertex for each inference. Let the vertex’s *color* indicate the model it came from (e.g. red for Model A, yellow for Model B). Draw an edge between two inferences if their bounding boxes overlap. Weight this edge by how much they overlap, in particular, their [*intersection over union*][intersection-over-union] (IoU) score.
 
-![]({{ site.github.url }}/assets/img/obj/ex-2.jpeg)
+![A graph connecting nearby centers of the four overlapping detections]({{ site.github.url }}/assets/img/obj/ex-2.jpeg)
 _A graph representation of our inferences, where weighted edges join nodes whose bounding boxes intersect._
 
 Now we have a weighted undirected graph. Our goal is to partition each disjoint subgraph into *cliques* such that no two vertices in a clique share the same color. We also want the cliques to have the maximum sum of edge weights (be as overlapping as possible). We take a greedy approach to this. First, we create a clique for each vertex. Then, we sort the edges by edge weight (IoU score). In descending order of edge weight, merge the two cliques the edges would connect if their sets of vertex colors are disjoint. A pseudocode implementation of this is below.
@@ -111,7 +111,7 @@ for edge in edges:
 return set(vertex_to_clique_map.values())
 ```
 
-![]({{ site.github.url }}/assets/img/obj/ex-3.jpeg)
+![The detection graph grouped into three possible cliques]({{ site.github.url }}/assets/img/obj/ex-3.jpeg)
 _We’ve grouped the detections into three cliques. The clique on the left contains two inferences._
 
 #### Voting on cliques
@@ -120,7 +120,7 @@ Now we have cliques of inferences that each refer to one object in the image. Wh
 
 Suppose we had a voting threshold of 0.5, so both models need to vote for a clique for us to accept it. Then we’d reject Clique 2 and Clique 3 because they each only have one vote, but we’d accept Clique 1 because it has two votes.
 
-![]({{ site.github.url }}/assets/img/obj/ex-4.jpeg)
+![The detection graph with the selected maximum clique emphasized]({{ site.github.url }}/assets/img/obj/ex-4.jpeg)
 _Results of ensemble detection after voting: only accept Clique 1._
 
 After voting, we only accept Clique 1. We finally compute the combined score of Clique 1 as a function of its inferences, and output a representative bounding box for this clique with that combined score as its confidence score.
@@ -131,12 +131,18 @@ Through effective grouping and voting schemes, multiple object detection models 
 
 We hope other computer vision teams can apply this technique to make more accurate and robust detection systems.
 
-![]({{ site.github.url }}/assets/img/obj/detections.gif)
+![Animation of an ensemble model combining detections around a knife in a suitcase X-ray]({{ site.github.url }}/assets/img/obj/detections.gif)
 _Some cool detections we’ve made at Synapse Technology, including handguns, gun parts, ammunition, razor blades, and fixed and folding knives._
 
-*I designed and implemented this system over the course of my one-month internship at [Synapse Technology](https://www.synapsetechnology.com/) ([acquired][acquisition]) this January. Thanks to my mentor Steven for thoughtful design documents and whiteboard sessions. Thanks to Sims for encouraging me to share my work, as well as the rest of the engineering team for a fun and productive internship.*
+*I designed and implemented this system over the course of my one-month internship at [Synapse Technology][synapse] ([acquired][acquisition]) this January. Thanks to my mentor Steven for thoughtful design documents and whiteboard sessions. Thanks to Sims for encouraging me to share my work, as well as the rest of the engineering team for a fun and productive internship.*
 
 _Thanks to Noah Moroze, Simanta Gautam, Bruno B. Ferrari Faviero, Ian Cinnamon, and Sanjeevani Lakshmivarahan for feeback. This blog post was cross-posted on Medium [here][medium]._
 
+[ancaro-project]: https://unsplash.com/photos/6VQlKJp2vpo?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText
+[unsplash]: https://unsplash.com/?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText
+[cognitive-fatigue]: https://medium.com/synapse-blog/tsa-missed-at-least-three-firearms-in-2018-why-theyll-keep-missing-threats-in-2019-5176ea0773bf
+[ai-performance]: https://medium.com/synapse-blog/ai-outperforms-certified-xray-operators-972932086f2e
+[intersection-over-union]: https://en.wikipedia.org/wiki/Jaccard_index
+[synapse]: https://www.forbes.com/profile/synapse-technology-corporation/
 [medium]: https://medium.com/synapse-blog/tech-deep-dive-object-detection-ensembles-as-graph-cliques-a7f7d33b5477
 [acquisition]: https://www.businesswire.com/news/home/20200610005917/en/Rapiscan-Continues-Innovation-Leadership-with-Acquisition-of-Advanced-Artificial-Intelligence-AI-Technology

--- a/_posts/2023-07-25-jep.md
+++ b/_posts/2023-07-25-jep.md
@@ -309,5 +309,5 @@ improvements. Play a game [here][jep] and check out the code [here][github]!
 [websockets]: https://en.wikipedia.org/wiki/WebSocket
 [supabase-realtime]: https://supabase.com/realtime
 [event-sourcing]: https://learn.microsoft.com/en-us/azure/architecture/patterns/event-sourcing
-[d4ac]: https://downforacross.com/
+[d4ac]: https://github.com/downforacross/downforacross.com
 [enhancements]: https://github.com/cmnord/jep/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement

--- a/_posts/2026-08-11-whoport.md
+++ b/_posts/2026-08-11-whoport.md
@@ -31,7 +31,8 @@ Hey! **Who is using `localhost:3000` ?!**
 
 ## How to use `whoport`
 
-`whoport` is my new [small, sharp tool][unix] to solve this. Pass in a port and it'll tell you what command (and therefore what path -> project + worktree) is using it:
+<!-- HTMLProofer: preserve this exact citation; www.catb.org has no valid HTTPS endpoint. -->
+`whoport` is my new [small, sharp tool][unix]{: data-proofer-ignore="" } to solve this. Pass in a port and it'll tell you what command (and therefore what path -> project + worktree) is using it:
 
 ```console?prompt=%25&lang=zsh
 % whoport 3000

--- a/menu/research.md
+++ b/menu/research.md
@@ -37,11 +37,11 @@ _[MIT M.Eng thesis 2020][dspace]_
 [tortis-teaser]: {{site.github.url}}/assets/video/RTSS2021-TORTIS-teaser.mp4
 [gscholar]: https://scholar.google.com/citations?user=FdBYqlcAAAAJ&hl=en
 [tortis-pdf]: https://www.cs.unc.edu/~anderson/papers/rtss21a.pdf
-[rtss]: http://2021.rtss.org/
+[rtss]: https://2021.rtss.org/
 [dspace]: https://dspace.mit.edu/handle/1721.1/129216
-[thesis-pdf]: http://web.mit.edu/ha22286/www/papers/MEng20_2.pdf
+[thesis-pdf]: https://web.mit.edu/ha22286/www/papers/MEng20_2.pdf
 [tortis-artifact]: https://github.com/scaspin/RTSS21-Artifact
 [tortis-code]: https://github.com/mit-ll/TORTIS
-[tortis-talk]: https://tu-dortmund.sciebo.de/s/icJpuYehGqZs6dM#/
+[tortis-talk]: https://tu-dortmund.sciebo.de/s/icJpuYehGqZs6dM
 [tortis-slides]: https://docs.google.com/presentation/d/e/2PACX-1vQkKWF1utgU62Fn6npbQr5EUCH39aJc2NQ02D9UzCR7QCw88uvx0Yc3drb2JtjFrqSC0CC81TYFHUw8/pub?start=false&loop=false&delayms=3000#slide=id.gf75a088714_0_18
 [thesis-award]: https://www.eecs.mit.edu/2021-eecs-awards/

--- a/scripts/check-html.sh
+++ b/scripts/check-html.sh
@@ -19,10 +19,12 @@ htmlproofer_ignored_urls=(
   '/underground-guide\.mit\.edu/'
 
   # These domains reject automated link checks with status 403.
+  '/beaumont\.org/'
   '/medium\.com/'
   '/medical-dictionary\.thefreedictionary\.com/'
   '/scholar\.google\.com/'
   '/stackoverflow\.com/'
+  '/tizen\.org/'
 
   # LinkedIn rejects automated link checks with status 999.
   '/linkedin\.com/'

--- a/scripts/check-html.sh
+++ b/scripts/check-html.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Validate generated HTML links, URL fragments, images, image alt text, and scripts.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+htmlproofer_ignored_urls=(
+  # Business Wire closes the checker's HTTP/2 connection with an internal error.
+  '/businesswire\.com/'
+  # Google returns 410 to the checker for this intentionally preserved published deck.
+  '/docs\.google\.com\/presentation/'
+
+  # These MIT HKN sites present certificate chains the checker cannot validate.
+  '/hkn\.mit\.edu/'
+  '/hkn-tutoring2\.mit\.edu/'
+  '/underground-guide\.mit\.edu/'
+
+  # These domains reject automated link checks with status 403.
+  '/medium\.com/'
+  '/medical-dictionary\.thefreedictionary\.com/'
+  '/scholar\.google\.com/'
+  '/stackoverflow\.com/'
+
+  # LinkedIn rejects automated link checks with status 999.
+  '/linkedin\.com/'
+  # Unsplash rejects automated link checks with status 401.
+  '/unsplash\.com/'
+)
+
+htmlproofer_ignore_arg=$(IFS=,; echo "${htmlproofer_ignored_urls[*]}")
+bundle exec htmlproofer ./_site \
+  --no-ignore-empty-alt \
+  --ignore-urls "$htmlproofer_ignore_arg"


### PR DESCRIPTION
Adds HTMLProofer to CI through a reusable local script, with documented exceptions for sites that block automated checks. Fixes missing image alt text across posts and standardizes external Markdown links as bottom-of-file references. Repairs verified stale destinations while preserving exact historical citations through explicit per-link exceptions where HTTPS is unavailable. Updates the README with the local validation command.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/2e15cdb5-9fcf-45b4-a1b4-2b936231156f)
